### PR TITLE
Delete Vocab.m

### DIFF
--- a/matlab/autogenerated/+yarp/Vocab.m
+++ b/matlab/autogenerated/+yarp/Vocab.m
@@ -1,6 +1,0 @@
-function varargout = VOCAB(varargin)
-    %Usage: retval = VOCAB (a, b, c, d)
-    %
-    %a is of type char. b is of type char. c is of type char. d is of type char. a is of type char. b is of type char. c is of type char. d is of type char. retval is of type int32_t. 
-  [varargout{1:nargout}] = yarpMEX(206, varargin{:});
-end


### PR DESCRIPTION
As the 206 id is already used by the encode.m function (as you can double check in the generated `yarpMATLAB_wrap.cxx` file, see the line `case 206: return "_wrap_encode";`), I think this file is just a left over, and that can be safely removed. 

Fix https://github.com/robotology-playground/yarp-matlab-bindings/issues/42 .