### PR TITLE
Fix find_package(MATLAB) to do not search for not necessary components

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -93,10 +93,7 @@ set(swig_other_sources)
 
 # Set the generated mex name to be yarpMEX, as it the defaul one used by SWIG while generating bindings
 if(YARP_USES_MATLAB)
-  find_package(Matlab
-          REQUIRED
-          MX_LIBRARY
-          MAIN_PROGRAM)
+  find_package(Matlab REQUIRED)
 
   swig_compile_module(${mexname} matlab)
   target_link_libraries(${mexname} ${Matlab_LIBRARIES} ${YARP_LIBRARIES})


### PR DESCRIPTION
MAIN_PROGRAM is not an actually required component for compilation of bindings.