### PR TITLE
Fix MATLAB compilation

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -93,7 +93,8 @@ set(swig_other_sources)
 
 # Set the generated mex name to be yarpMEX, as it the defaul one used by SWIG while generating bindings
 if(YARP_USES_MATLAB)
-  find_package(Matlab REQUIRED)
+  find_package(Matlab REQUIRED
+                      COMPONENTS MX_LIBRARY)
 
   swig_compile_module(${mexname} matlab)
   target_link_libraries(${mexname} ${Matlab_LIBRARIES} ${YARP_LIBRARIES})


### PR DESCRIPTION
The PR https://github.com/robotology/yarp-matlab-bindings/pull/56 contained a regression, as this repo vendors an old FindMatlab module for which indeed MX_LIBRARY is a valid component, and actually a a required one. While cleaning up the repo from this old FindMatlab can be done in the future, currently the fastest fix is to add MX_LIBRARY back. 