### PR TITLE
On Windows always export the mexFunction symbol

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -106,6 +106,7 @@ if(YARP_USES_MATLAB)
     set_target_properties(${mexname}
             PROPERTIES
             DEFINE_SYMBOL "DLL_EXPORT_SYM=__declspec(dllexport)")
+    target_link_options(${mexname} PRIVATE "/EXPORT:mexFunction")
   endif()
 
   # Install the generated front-end to ${CMAKE_INSTALL_PREFIX}/mex


### PR DESCRIPTION
Fix https://github.com/robotology/yarp-matlab-bindings/issues/58 . 