### PR TITLE
Do not set C++11 explicitly on macOS [yarp-3.4]

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -125,18 +125,6 @@ if(YARP_USES_MATLAB)
   install(FILES ${MEX_BINDINGS_SOURCE_DIR}/SwigGet.m DESTINATION ${CMAKE_INSTALL_PREFIX}/${YARP_INSTALL_MATLAB_MFILESDIR})
   install(FILES ${MEX_BINDINGS_SOURCE_DIR}/SwigStorage.m DESTINATION ${CMAKE_INSTALL_PREFIX}/${YARP_INSTALL_MATLAB_MFILESDIR})
   install(TARGETS ${mexname} DESTINATION ${CMAKE_INSTALL_PREFIX}/${YARP_INSTALL_MATLAB_LIBDIR})
-
-  #On new versions of Clang, MATLAB requires C++11.
-  #I enable it on all Clangs
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-      if (${CMAKE_GENERATOR} MATCHES "Xcode")
-        #this should set explictly the option in xcode. Unfortunately it does not work.
-        set(XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "C++11")
-      endif(${CMAKE_GENERATOR} MATCHES "Xcode")
-    endif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-  endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 if(YARP_USES_OCTAVE)


### PR DESCRIPTION
YARP exports the C++14 compilation requirements since a long time, so setting `-std=c++11` manually just creates problems in code that actually requires C++14.

This should fix the problem in https://github.com/robotology/robotology-superbuild/pull/644 .