### PR TITLE
Add conda-based CI

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -117,7 +117,7 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ldd ./lib/yarpMEX.mexa64
+        ldd ./matlab/yarpMEX.mexa64
 
     - name: Install [Conda]
       shell: bash -l {0}

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -60,10 +60,8 @@ jobs:
         conda install -c conda-forge mamba
         # Compilation related dependencies 
         mamba install -c conda-forge cmake compilers make ninja pkg-config
-        # Actual dependencies
-        mamba install -c conda-forge eigen 
         # YARP dependencies 
-        mamba install -c conda-forge ace eigen
+        mamba install -c conda-forge ace eigen ycm-cmake-modules
         # Uncomment when we are compatible with releases in conda yarp
         # mamba install -c conda-forge -c robotology yarp 
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -74,7 +74,7 @@ jobs:
         cd yarp
         mkdir build
         cd build
-        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DYARP_COMPILE_EXECUTABLES:BOOL=OFF ..
         cmake --build . --config ${{ matrix.build_type }}        
         cmake --install . --config ${{ matrix.build_type }}
                 
@@ -86,7 +86,7 @@ jobs:
         cd yarp
         mkdir build
         cd build
-        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DYARP_COMPILE_EXECUTABLES:BOOL=OFF ..
         cmake --build . --config ${{ matrix.build_type }}        
         cmake --install . --config ${{ matrix.build_type }}
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -62,6 +62,8 @@ jobs:
         mamba install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
         mamba install -c conda-forge eigen 
+        # YARP dependencies 
+        mamba install -c conda-forge ace eigen
         # Uncomment when we are compatible with releases in conda yarp
         # mamba install -c conda-forge -c robotology yarp 
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -61,7 +61,7 @@ jobs:
         # Compilation related dependencies 
         mamba install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge eigen yarp
+        mamba install -c conda-forge -c robotology eigen yarp
 
     - name: Configure [Conda/Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -1,0 +1,101 @@
+name: C++ CI Workflow
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+  
+jobs:
+  build-with-conda-dependencies:    
+    name: '[conda:${{ matrix.os }}]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+
+    - name: Install files to enable compilation of mex files [Conda/Linux]
+      if: contains(matrix.os, 'ubuntu') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020b_mexa64.zip
+        unzip msdk_R2020b_mexa64.zip
+        rm msdk_R2020b_mexa64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020b_mexa64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexa64" >> $GITHUB_ENV
+                
+    - name: Install files to enable compilation of mex files [Conda/macOS]
+      if: contains(matrix.os, 'macos') 
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexmaci64.zip
+        unzip msdk_R2020a_mexmaci64.zip
+        rm msdk_R2020a_mexmaci64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexmaci64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexmaci64" >> $GITHUB_ENV
+        
+    - name: Install files to enable compilation of mex files [Conda/Windows]
+      if: contains(matrix.os, 'windows') 
+      shell: bash
+      run: |
+        curl -L -O https://github.com/robotology/robotology-vcpkg-ports/releases/download/storage/msdk_R2020a_mexw64.zip
+        unzip msdk_R2020a_mexw64.zip
+        rm msdk_R2020a_mexw64.zip
+        echo "GHA_Matlab_ROOT_DIR=${GITHUB_WORKSPACE}/msdk_R2020a_mexw64" >> $GITHUB_ENV
+        echo "GHA_Matlab_MEX_EXTENSION=mexw64" >> $GITHUB_ENV
+
+    - name: Dependencies [Conda]
+      shell: bash -l {0}
+      run: |
+        # Install mamba (https://github.com/mamba-org/mamba) as first step 
+        conda install -c conda-forge mamba
+        # Compilation related dependencies 
+        mamba install -c conda-forge cmake compilers make ninja pkg-config
+        # Actual dependencies
+        mamba install -c conda-forge eigen yarp
+
+    - name: Configure [Conda/Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir build
+        cd build
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
+
+    - name: Configure [Conda/Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir build
+        cd build
+        cmake -G"Visual Studio 16 2019"  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON  -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
+
+    - name: Build [Conda]
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Inspect libraries linked by iDynTreeMEX.mexa64 [Conda/Linux]
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        cd build
+        ldd ./lib/yarpMEX.mexa64
+
+    - name: Install [Conda]
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --install . --config ${{ matrix.build_type }}
+
+ 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -112,7 +112,7 @@ jobs:
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
-    - name: Inspect libraries linked by iDynTreeMEX.mexa64 [Conda/Linux]
+    - name: Inspect libraries linked by yarpMEX.mexa64 [Conda/Linux]
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -61,7 +61,34 @@ jobs:
         # Compilation related dependencies 
         mamba install -c conda-forge cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robotology eigen yarp
+        mamba install -c conda-forge eigen 
+        # Uncomment when we are compatible with releases in conda yarp
+        # mamba install -c conda-forge -c robotology yarp 
+
+
+    - name: Install YARP [Conda/Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        git clone https://github.com/robotology/yarp
+        cd yarp
+        mkdir build
+        cd build
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake --build . --config ${{ matrix.build_type }}        
+        cmake --install . --config ${{ matrix.build_type }}
+                
+    - name:  Install YARP [Conda/Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        git clone https://github.com/robotology/yarp
+        cd yarp
+        mkdir build
+        cd build
+        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake --build . --config ${{ matrix.build_type }}        
+        cmake --install . --config ${{ matrix.build_type }}
 
     - name: Configure [Conda/Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -69,7 +96,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
 
     - name: Configure [Conda/Windows]
       if: contains(matrix.os, 'windows')
@@ -77,7 +104,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G"Visual Studio 16 2019"  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON  -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
+        cmake -G"Visual Studio 16 2019"  -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DMATLAB_FIND_DEBUG:BOOL=ON  -DYARP_USES_MATLAB:BOOL=ON -DMatlab_ROOT_DIR=${GHA_Matlab_ROOT_DIR} -DMatlab_MEX_EXTENSION:STRING=${GHA_Matlab_MEX_EXTENSION} ..
 
     - name: Build [Conda]
       shell: bash -l {0}

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -107,7 +107,7 @@ if(YARP_USES_MATLAB)
 
   swig_compile_module(${mexname} matlab)
   target_link_libraries(${mexname} ${Matlab_LIBRARIES} ${YARP_LIBRARIES})
-  target_include_directories(${mexname} PUBLIC ${Matlab_INCLUDE_DIRS})
+  target_include_directories(${mexname} PRIVATE ${Matlab_INCLUDE_DIRS})
 
   set_target_properties(${mexname} PROPERTIES PREFIX "" SUFFIX .${Matlab_MEX_EXTENSION})
   # entry point in the mex file + taking care of visibility and symbol clashes.


### PR DESCRIPTION
Add a basic conda-based CI to ensure that when MATLAB bindings are regenerate they correctly compile.