### PR TITLE
Fix Conda CI on Linux by using Mambaforge and explicity excluding defaults

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -23,7 +23,9 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        auto-update-conda: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        channels: conda-forge,robotology
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu') 
@@ -56,14 +58,14 @@ jobs:
     - name: Dependencies [Conda]
       shell: bash -l {0}
       run: |
-        # Install mamba (https://github.com/mamba-org/mamba) as first step 
-        conda install -c conda-forge mamba
+        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
+        conda config --remove channels defaults
         # Compilation related dependencies 
-        mamba install -c conda-forge cmake compilers make ninja pkg-config
+        mamba install cmake compilers make ninja pkg-config
         # YARP dependencies 
-        mamba install -c conda-forge ace eigen ycm-cmake-modules
+        mamba install ace eigen ycm-cmake-modules
         # Uncomment when we are compatible with releases in conda yarp
-        # mamba install -c conda-forge -c robotology yarp 
+        # mamba install yarp 
 
 
     - name: Install YARP [Conda/Linux&macOS]


### PR DESCRIPTION
Similar to https://github.com/robotology/idyntree/pull/910 .