### PR TITLE
Update SWIG fork with changes from swig 4

### DIFF
--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -50,8 +50,7 @@ jobs:
             gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
             gstreamer1.0-libav liboctave-dev
             # Clone YARP
-            # git clone https://github.com/robotology/yarp -b ${GIT_BRANCH_NAME}
-            git clone https://github.com/robotology/yarp -b master
+            git clone https://github.com/robotology/yarp -b ${GIT_BRANCH_NAME}
             # Configure, build and install YARP and regenerate yarp-matlab-bindings
             cd yarp
             mkdir build

--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -16,7 +16,7 @@ jobs:
           run: |
             sudo apt-get remove swig swig4.0
             cd ..
-            git clone https://github.com/KrisThielemans
+            git clone https://github.com/KrisThielemans/swig
             cd swig
             git checkout matlab-update
             sh autogen.sh

--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -16,9 +16,9 @@ jobs:
           run: |
             sudo apt-get remove swig swig4.0
             cd ..
-            git clone https://github.com/robotology-dependencies/swig/
+            git clone https://github.com/KrisThielemans
             cd swig
-            git checkout matlab
+            git checkout matlab-update
             sh autogen.sh
             ./configure --with-matlab
             make 

--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -50,7 +50,8 @@ jobs:
             gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
             gstreamer1.0-libav liboctave-dev
             # Clone YARP
-            git clone https://github.com/robotology/yarp -b ${GIT_BRANCH_NAME}
+            # git clone https://github.com/robotology/yarp -b ${GIT_BRANCH_NAME}
+            git clone https://github.com/robotology/yarp -b master
             # Configure, build and install YARP and regenerate yarp-matlab-bindings
             cd yarp
             mkdir build


### PR DESCRIPTION
Testing https://github.com/jaeandersson/swig/pull/96 as YARP 3.6 now requires SWIG 4.