### PR TITLE
Fix regenerate-matlab-bindings action when used on different branches at the same time

### DIFF
--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -88,7 +88,7 @@ jobs:
           with:
             commit-message: 'update matlab bindings'
             committer: GitHub <noreply@github.com>
-            branch: regenerate-matlab-bindings
+            branch: regenerate-matlab-bindings-${GIT_BRANCH_NAME}
             delete-branch: true
             title: 'update matlab bindings'
             body: |

--- a/.github/workflows/regenerate-matlab-bindings.yml
+++ b/.github/workflows/regenerate-matlab-bindings.yml
@@ -88,7 +88,7 @@ jobs:
           with:
             commit-message: 'update matlab bindings'
             committer: GitHub <noreply@github.com>
-            branch: regenerate-matlab-bindings-${GIT_BRANCH_NAME}
+            branch: regenerate-matlab-bindings-${{ env.GIT_BRANCH_NAME }}
             delete-branch: true
             title: 'update matlab bindings'
             body: |


### PR DESCRIPTION
If the action was used on different branches, the result was pushed anyhow on the `regenerate-matlab-bindings` branch. This create cross-talking, that we solve by using always a different name for the branch.