### PR TITLE
Only link required MATLAB libraries

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -106,7 +106,7 @@ if(YARP_USES_MATLAB)
                       COMPONENTS MX_LIBRARY)
 
   swig_compile_module(${mexname} matlab)
-  target_link_libraries(${mexname} ${Matlab_LIBRARIES} ${YARP_LIBRARIES})
+  target_link_libraries(${mexname} ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} ${YARP_LIBRARIES})
   target_include_directories(${mexname} PRIVATE ${Matlab_INCLUDE_DIRS})
 
   set_target_properties(${mexname} PROPERTIES PREFIX "" SUFFIX .${Matlab_MEX_EXTENSION})


### PR DESCRIPTION
On some platforms, `Matlab_LIBRARIES` contains libraries such as `libMatlabEngine.so` that are not part of all matlab installations. So, it is better to explicitly link only the required libraries, to avoid problems when a binary is compiled in a system with `libMatlabEngine.so` and used in a system without `libMatlabEngine.so`, generating problems such as https://github.com/robotology/robotology-superbuild/issues/1194 .

