### PR TITLE
Remove robotology channel from CI

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
-        channels: conda-forge,robotology
+        channels: conda-forge
 
     - name: Install files to enable compilation of mex files [Conda/Linux]
       if: contains(matrix.os, 'ubuntu') 


### PR DESCRIPTION
It is not needed anymore since we moved yarp to conda-forge, and it mitigates against performance problems in non-conda-forge repos such as https://github.com/conda/infrastructure/issues/906 and https://github.com/conda/infrastructure/issues/899 .