### PR TITLE
removed topIsLowIndex, setTopIsLowIndex functions for yarp Image datatype

### DIFF
--- a/matlab/autogenerated/+yarp/Image.m
+++ b/matlab/autogenerated/+yarp/Image.m
@@ -145,18 +145,6 @@ classdef Image < yarp.Portable
     %imgQuantum is of type size_t. 
       [varargout{1:nargout}] = yarpMEX(841, self, varargin{:});
     end
-    function varargout = topIsLowIndex(self,varargin)
-    %Usage: retval = topIsLowIndex ()
-    %
-    %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(842, self, varargin{:});
-    end
-    function varargout = setTopIsLowIndex(self,varargin)
-    %Usage: setTopIsLowIndex (flag)
-    %
-    %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(843, self, varargin{:});
-    end
     function varargout = getRowArray(self,varargin)
     %Usage: retval = getRowArray ()
     %


### PR DESCRIPTION
removed topIsLowIndex, setTopIsLowIndex functions: they are not supported anymore by yarp.

NB: In the following commit the relevant code has been removed manually, without regenerating the files. This should be enough to prevent the functions to be called by user applications, until yarp 3.10 is released and the whole repo can be regenerated.