### PR TITLE
Drop deprecated mambaforge installer and use conda instead of mamba

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -21,9 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         channels: conda-forge
 
@@ -61,9 +60,9 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies 
-        mamba install cmake compilers make ninja pkg-config
+        conda  install cmake compilers make ninja pkg-config
         # YARP dependencies 
-        mamba install ace eigen ycm-cmake-modules
+        conda install ace eigen ycm-cmake-modules
         # Uncomment when we are compatible with releases in conda yarp
         # mamba install yarp 
 


### PR DESCRIPTION
The `mambaforge` installer is now deprecated and is failing more and more frequently, and will stop working in 2025 (see https://github.com/conda-forge/miniforge?tab=readme-ov-file#should-i-choose-one-or-another-going-forward-at-the-risk-of-one-of-them-getting-deprecated), so we switch to just use `miniforge` .

On the other hand, `conda` is now as fast as `mamba` (see https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), so to simplify the CI script we can always use conda instead of alternating conda and mamba.